### PR TITLE
feat(metalayer): add support for metalayer [PRO-47]

### DIFF
--- a/config/default.ts
+++ b/config/default.ts
@@ -82,6 +82,7 @@ export default {
     proofs: {
       storage_duration_seconds: 604800,
       hyperlane_duration_seconds: 3600,
+      metalayer_duration_seconds: 3600,
     },
   },
   liquidityManager: {

--- a/config/development.ts
+++ b/config/development.ts
@@ -92,4 +92,11 @@ export default {
       chainID: 11155420,
     },
   },
+  intentConfigs: {
+    proofs: {
+      storage_duration_seconds: 60,
+      hyperlane_duration_seconds: 120,
+      metalayer_duration_seconds: 180,
+    },
+  },
 }

--- a/src/contracts/prover.ts
+++ b/src/contracts/prover.ts
@@ -1,9 +1,11 @@
 export const PROOF_STORAGE = 0
 export const PROOF_HYPERLANE = 1
+export const PROOF_METALAYER = 2
 
-export type ProofType = typeof PROOF_STORAGE | typeof PROOF_HYPERLANE
+export type ProofType = typeof PROOF_STORAGE | typeof PROOF_HYPERLANE | typeof PROOF_METALAYER
 
 export const Proofs: Record<string, ProofType> = {
   Storage: PROOF_STORAGE,
   Hyperlane: PROOF_HYPERLANE,
+  Metalayer: PROOF_METALAYER,
 }

--- a/src/eco-configs/eco-config.types.ts
+++ b/src/eco-configs/eco-config.types.ts
@@ -122,6 +122,7 @@ export type IntentConfig = {
   proofs: {
     storage_duration_seconds: number
     hyperlane_duration_seconds: number
+    metalayer_duration_seconds: number
   }
 }
 

--- a/src/prover/proof.service.ts
+++ b/src/prover/proof.service.ts
@@ -5,6 +5,7 @@ import { Hex } from 'viem'
 import {
   PROOF_HYPERLANE,
   PROOF_STORAGE,
+  PROOF_METALAYER,
   ProofCall,
   ProofType,
   ProverInterfaceAbi,
@@ -61,6 +62,15 @@ export class ProofService implements OnModuleInit {
    */
   isStorageProver(proverAddress: Hex): boolean {
     return this.getProofType(proverAddress) === PROOF_STORAGE
+  }
+
+  /**
+   * Checks if the prover is a metalayer prover
+   * @param proverAddress the prover address
+   * @returns
+   */
+  isMetalayerProver(proverAddress: Hex): boolean {
+    return this.getProofType(proverAddress) === PROOF_METALAYER
   }
 
   /**
@@ -176,6 +186,8 @@ export class ProofService implements OnModuleInit {
     switch (prover) {
       case PROOF_HYPERLANE:
         return proofs.hyperlane_duration_seconds
+      case PROOF_METALAYER:
+        return proofs.metalayer_duration_seconds
       case PROOF_STORAGE:
       default:
         return proofs.storage_duration_seconds


### PR DESCRIPTION
This set of changes introduce support for Metalayer as a possible route for Eco's solver implementation. 

**Note that there is currently a hack in `fulfill-intent.service.ts`** that shoehorns in an additional function name to the ABI which is necessary until Eco's upstream `@eco-foundation/routes-ts` package is updated to a version with Metalayer support.